### PR TITLE
exclude admin from monitoring of url message

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,10 @@ client.on('messageUpdate', (oldMessage, newMessage) => {
 client.login(env.token)
 
 function checkMessage(message) {
-  if (message.author.bot || message.system) return true;
-  if (message.guild && message.guild.id != '797157625195659264') return true;
+  if (message.author.bot || message.system) return true
+  if (message.guild && message.guild.id != '797157625195659264') return true
+  if (message.member.hasPermission('MANAGE_MESSAGES')) return true
   const content = message.content.toLowerCase();
-  if (content.includes('http://') || content.includes('https://')) return false;
-  return true;
+  if (content.includes('http://') || content.includes('https://')) return false
+  return true
 }


### PR DESCRIPTION
exclude admin (who has the permission of "MANAGE_MESSAGES") from monitoring of url message
_**in this update, the bot needs to have the permission of "MANAGE_ROLES" so be carefull.**_